### PR TITLE
Turn logging down to warn b/c it dumps params

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -41,7 +41,7 @@ Rails.application.configure do
 
   # Use the lowest log level to ensure availability of diagnostic information
   # when problems arise.
-  config.log_level = :debug
+  config.log_level = :warn
 
   # Prepend all log lines with the following tags.
   config.log_tags = [ :request_id ]


### PR DESCRIPTION
@mathias @mikehale could you review?  I do not like it dumping events to the log so I bumped all the way up to `warn` because there is no easy to disable dumping the params on an action or controller basis