### PR TITLE
Replace dashboard_path usage with root_path

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -18,7 +18,7 @@ class SessionsController < ApplicationController
     session[:token] = request.env['omniauth.auth']['credentials']['token']
     session[:email] = request.env['omniauth.auth']['info']['email']
 
-    redirect_to "/dashboard"
+    redirect_to root_path
   end
 
   def logout

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,7 +3,6 @@ Rails.application.routes.draw do
 
   resources :webhooks, only: [:create]
   resources :events, only: [:index]
-  resources :dashboard, only: [:index]
   resources :setup, only: [:index]
 
   root to: "dashboard#index"

--- a/spec/requests/dashboard_spec.rb
+++ b/spec/requests/dashboard_spec.rb
@@ -2,35 +2,35 @@ require "rails_helper"
 
 RSpec.describe "Dashboard", type: :request do
   it 'redirects to login when no session' do
-    get dashboard_index_path, as: :html
+    get root_path, as: :html
     expect(response).to redirect_to login_path
   end
 
   it 'redirects to login when token expires' do
     login status: 401
 
-    get dashboard_index_path, as: :html
+    get root_path, as: :html
     expect(response).to redirect_to login_path
   end
 
   it 'forbids when not authorized to app' do
     login status: 403
 
-    get dashboard_index_path, as: :html
+    get root_path, as: :html
     expect(response).to have_http_status(:forbidden)
   end
 
   it 'not founds when app is not found' do
     login status: 404
 
-    get dashboard_index_path, as: :html
+    get root_path, as: :html
     expect(response).to have_http_status(:not_found)
   end
 
   it 'renders events when allowed' do
     login
 
-    get dashboard_index_path, as: :html
+    get root_path, as: :html
     expect(response).to have_http_status(:ok)
   end
 end


### PR DESCRIPTION
@mathias @mikehale could you review?  I noticed a bug in the active tab javascript in the one place that `/dashboard` was used so I removed `dashboard_path` so that it can only be referenced via `root_path`