### PR TITLE
Add protect_from_forgery back in web controllers

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -16,5 +16,5 @@ class ApplicationController < ActionController::Base
     end
   end
 
-  #protect_from_forgery with: :exception
+  protect_from_forgery with: :exception
 end


### PR DESCRIPTION
@mathias @mikehale could you review?  just adding back in protect_from_forgery since we stopped using this as a base for API controllers and instead are using as a base for web controllers.