### PR TITLE
Replace plugins:install command with heroku update

### DIFF
--- a/app/views/setup/index.html.erb
+++ b/app/views/setup/index.html.erb
@@ -9,9 +9,13 @@
       </p>
     </section>
     <section class="mb5">
-      <div class="f3 mb4 lh-title">1. Setting up the webhooks CLI plugin</div>
+      <div class="f3 mb4 lh-title">1. Update the Heroku CLI</div>
+      <p class="f4 dark-gray lh-copy">
+        Commands for managing app webhooks are available in version heroku-cli/6.13.19 and later of the Heroku CLI.
+        To ensure that you are using the latest version of the CLI, run the following command:
+      </p>
       <div class="code-block relative lh-copy mv3 w-100 bg-light-silver  code pa2 pl5 dark-gray ba b--silver br1 word-wrap">
-        <div>heroku plugins:install heroku-webhooks</div>
+        <div>heroku update</div>
       </div>
     </section>
 
@@ -19,7 +23,9 @@
 
     <section class="mb5 br1">
       <div class="lh-copy w-100 bg-black code pa2 pl4 white word-wrap br1">
-        <div>Installing plugin heroku-webhooks... done</div>
+        <div>heroku-cli: Updating to 6.13.19-6cd27b3... 12.7 MB/12.7 MB</div>
+        <div>heroku-cli: Updating CLI... already on latest version: 6.13.19-6cd27b3</div>
+        <div>heroku-cli: Updating plugins... done</div>
       </div>
     </section>
 


### PR DESCRIPTION
@mathias @mikehale could you review?  the plugin is in core so we want people to update their CLI rather than installing the plugin