### PR TITLE
Fix events disappearing when > 100 events

### DIFF
--- a/app/assets/javascripts/dashboard.js
+++ b/app/assets/javascripts/dashboard.js
@@ -51,7 +51,7 @@ $(document).ready(function(){
   }
 
   $.ajax({url: "/events", dataType: 'json'}).done(function(events) {
-    events.forEach(function(data) {
+    events.reverse().forEach(function(data) {
       render(data, false)
     })
 

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -2,6 +2,6 @@ class EventsController < ApplicationController
   before_action :authenticate_user_action!
 
   def index
-    render json: Event.order(created_at: :asc).limit(100), each_serializer: EventSerializer
+    render json: Event.order(created_at: :desc).limit(100), each_serializer: EventSerializer
   end
 end

--- a/spec/requests/events_spec.rb
+++ b/spec/requests/events_spec.rb
@@ -41,12 +41,12 @@ RSpec.describe "Events", type: :request do
     expect(response).to have_http_status(:ok)
     expect(response.parsed_body).to eq([
       {
-        'payload' => {'foo' => 'bar'},
-        'created_at' => '2001-02-03T00:00:00.000Z'
-      },
-      {
         'payload' => {'biz' => 'baz'},
         'created_at' => '2001-02-04T00:00:00.000Z'
+      },
+      {
+        'payload' => {'foo' => 'bar'},
+        'created_at' => '2001-02-03T00:00:00.000Z'
       }
     ])
   end


### PR DESCRIPTION
@mathias @mikehale could you review?  I found that I stopped seeing events from the DB once it there were greater than 100 events.  I fixed the ordering of the events that we output via the API and updated the display log to handle.