### PR TITLE
Add omniauth-rails_csrf_protection & post button

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,6 +13,7 @@ gem 'uglifier'
 gem 'jquery-rails', '>= 4.3.5'
 gem 'active_model_serializers', '~> 0.10.10'
 gem 'omniauth-heroku'
+gem 'omniauth-rails_csrf_protection'
 gem 'platform-api'
 gem 'tzinfo-data'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -132,6 +132,9 @@ GEM
     omniauth-oauth2 (1.4.0)
       oauth2 (~> 1.0)
       omniauth (~> 1.2)
+    omniauth-rails_csrf_protection (0.1.2)
+      actionpack (>= 4.2)
+      omniauth (>= 1.3.1)
     pg (0.21.0)
     platform-api (2.1.0)
       heroics (~> 0.0.23)
@@ -229,6 +232,7 @@ DEPENDENCIES
   launchy
   multi_json
   omniauth-heroku
+  omniauth-rails_csrf_protection
   pg (~> 0.18)
   platform-api
   puma (~> 4.3)

--- a/app/controllers/authenticating_controller.rb
+++ b/app/controllers/authenticating_controller.rb
@@ -5,7 +5,7 @@ module AuthenticatingController
     if Rails.env.development?
       dev_app = ENV['DEVELOPMENT_APP']
       unless dev_app
-        raise 'Set DEVLOPMENT_APP to app to check auth against in dev'
+        raise 'Set DEVELOPMENT_APP to app to check auth against in dev'
       end
       dev_app
     else

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -3,7 +3,7 @@ require 'platform-api'
 class SessionsController < ApplicationController
   def new
     if ENV['HEROKU_OAUTH_ID'] && ENV['HEROKU_OAUTH_SECRET']
-      redirect_to "/auth/heroku"
+      render "redirect"
     else
       @app = heroku_app
       @oauth_name = request.host

--- a/app/views/sessions/new.html.erb
+++ b/app/views/sessions/new.html.erb
@@ -69,7 +69,7 @@
         <div class="f4 lh-copy dark-gray">
           You have now configured oAuth authorization for this app.
         </div>
-        <%= button_to "Login Now", root_path, class: "hk-button--primary mv4", method: "get", form_class: "w-100" %>
+        <%= button_to "Login Now", "/auth/heroku", class: "hk-button--primary mv4", form_class: "w-100" %>
       </section>
         <% end %>
   </div>

--- a/app/views/sessions/redirect.html.erb
+++ b/app/views/sessions/redirect.html.erb
@@ -1,0 +1,8 @@
+<div class="ph3 mv6 pv3">
+  <div class="dt w-100 w-80-l mw8 center">
+    <section class="mb5 pb2">
+      <div class="f3 lh-title">Log Into the App</div>
+      <%= button_to "Login Now", "/auth/heroku", class: "hk-button--primary mv4", form_class: "w-100" %>
+    </section>
+  </div>
+</div>

--- a/spec/requests/cors_spec.rb
+++ b/spec/requests/cors_spec.rb
@@ -1,0 +1,26 @@
+RSpec.describe 'CVE-2015-9284', type: :request do
+  describe 'GET /auth/:provider' do
+    it do
+      expect {
+        get '/auth/heroku'
+      }.to raise_error(ActionController::RoutingError)
+    end
+  end
+
+  describe 'POST /auth/:provider without CSRF token' do
+    before do
+      @allow_forgery_protection = ActionController::Base.allow_forgery_protection
+      ActionController::Base.allow_forgery_protection = true
+    end
+
+    it do
+      expect {
+        post '/auth/heroku'
+      }.to raise_error(ActionController::InvalidAuthenticityToken)
+    end
+
+    after do
+      ActionController::Base.allow_forgery_protection = @allow_forgery_protection
+    end
+  end
+end


### PR DESCRIPTION
This fixes this [omniauth](https://github.com/omniauth/omniauth/wiki/Resolving-CVE-2015-9284#mitigating-in-rails-applications) issue by following the remediation steps to remove the `GET /auth/heroku` endpoint.  Rather than doing a redirect to `/auth/heroku` to force users to login, we provide them with a button they must click on in order to login.  This is most easily tested by doing a [branch button deploy](https://dashboard.heroku.com/new?button-url=https%3A%2F%2Fgithub.com%2Fheroku%2Fwebhooks-demo%2Ftree%2Ffix-omni-auth-issue&template=https%3A%2F%2Fgithub.com%2Fheroku%2Fwebhooks-demo%2Ftree%2Ffix-omni-auth-issue) if you wanted to verify the look and feel by setting it up, logging out, then going back and logging in again so that you hit both the "Login Now" buttons.  I also verified that the `GET /auth/heroku` no longer works by doing a tweaked version of the suggested functional test.